### PR TITLE
Leave DefaultRelyingParty to original version

### DIFF
--- a/HOWTO Install and Configure a Shibboleth IdP v3.2.1 on Ubuntu Linux LTS 16.04 with Apache2 + Tomcat8.md
+++ b/HOWTO Install and Configure a Shibboleth IdP v3.2.1 on Ubuntu Linux LTS 16.04 with Apache2 + Tomcat8.md
@@ -343,27 +343,6 @@
       * ```vim /opt/shibboleth-idp/conf/c14n/subject-c14n.xml```
         * Remove the comment to the bean called "**c14n/SAML2Persistent**".
 
-        * Modify the ***DefaultRelyingParty*** to releasing of the "persistent-id" to all, ever:
-          * ```vim /opt/shibboleth-idp/conf/relying-party.xml```
-
-            ```xml
-            <bean id="shibboleth.DefaultRelyingParty" parent="RelyingParty">
-                <property name="profileConfigurations">
-                  <list>
-                      <bean parent="Shibboleth.SSO" p:postAuthenticationFlows="attributerelease" />
-                      <ref bean="SAML1.AttributeQuery" />
-                      <ref bean="SAML1.ArtifactResolution" />
-                      <bean parent="SAML2.SSO" p:postAuthenticationFlows="attribute-release" p:nameIDFormatPrecedence="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent" />
-                      <ref bean="SAML2.ECP" />
-                      <ref bean="SAML2.Logout" />
-                      <ref bean="SAML2.AttributeQuery" />
-                      <ref bean="SAML2.ArtifactResolution" />
-                      <ref bean="Liberty.SSOS" />
-                  </list>
-                </property>
-            </bean>
-            ```
-
 8. Enable **JPAStorageService** for the **StorageService** of the user consent:
   * ```vim /opt/shibboleth-idp/conf/global.xml``` and add to the tail of the file this piece code:
 


### PR DESCRIPTION
We don't need to modify the DefaultRelyingParty value to be able to release a persistent-id or a transient-id