### PR TITLE
Updated link.

### DIFF
--- a/HOWTO Install and Configure a Shibboleth v3.2.1 on Ubuntu Linux LTS 14.04 with Tomcat 8 only.md
+++ b/HOWTO Install and Configure a Shibboleth v3.2.1 on Ubuntu Linux LTS 14.04 with Tomcat 8 only.md
@@ -112,7 +112,7 @@
   * ```chmod g+r conf/*```
 
 11. Create the init.d service for restarting Tomcat 8:
-  * ```vim /etc/init.d/tomcat``` (and paste the content of the [daemon-tomcat](../blob/master/daemon-tomcat) file)
+  * ```vim /etc/init.d/tomcat``` (and paste the content of the [daemon-tomcat](../master/daemon-tomcat) file)
   * ```cd /usr/local/src```
   * ```chmod 755 /etc/init.d/tomcat```
   * ```update-rc.d tomcat defaults```


### PR DESCRIPTION
The current daemon-tomcat link is broken and points to:

https://github.com/malavolti/HOWTO-Install-and-Configure-Shibboleth-Identity-Provider/blob/blob/master/daemon-tomcat

Notice the double blob/blob.